### PR TITLE
Fund Code Triangulation LLM Verification

### DIFF
--- a/prism/reports/flaggers/work_flaggers.go
+++ b/prism/reports/flaggers/work_flaggers.go
@@ -402,7 +402,7 @@ func (flagger *OpenAlexAcknowledgementIsEOC) verifyGrantRecipientWithLLM(authorN
 		return true, fmt.Errorf("llm match verification failed: %w", err)
 	}
 
-	if strings.ToLower(res) == "true" {
+	if strings.Contains(strings.ToLower(res), "true") {
 		return true, nil
 	}
 


### PR DESCRIPTION
For fund code triangulation, we first check our triangulation db. In case the queried author is determined to be a primary recipient of the grant, we verify it with an LLM by sending it the acknowledgment text.

One issue that remains is that sometimes a grant code is acknowledged in some papers but not in others; this leads to us showing the queried author as a primary recipient for that grant for some papers and not for others. This was solved by storing the recipiency in a map and updating the flags at the end.

After processing all the acknowledgment flags, we update the triangulation flags from this recipiency map because we may have marked the author as a primary recipient for a grant code earlier and figured out that someone else is the actual primary recipient for that grant in a paper processed later.

[Jira Ticket](https://3rdai.atlassian.net/jira/software/projects/PRSM/boards/10?assignee=712020%3A905538cf-9530-4eac-b526-19e308fbdd72&selectedIssue=PRSM-148)