### PR TITLE
Revert "Filter list (#112)"

### DIFF
--- a/frontend/src/api/autocomplete.js
+++ b/frontend/src/api/autocomplete.js
@@ -2,9 +2,9 @@ import axiosInstance from './axios.config';
 import { API_ROUTES } from './constants';
 
 export const autocompleteService = {
-  autocompleteAuthors: async (query, institution_id) => {
+  autocompleteAuthors: async (query) => {
     const response = await axiosInstance.get(API_ROUTES.AUTOCOMPLETE.AUTHOR, {
-      params: { query, institution_id },
+      params: { query },
     });
     return response.data;
   },

--- a/frontend/src/components/common/searchBar/SearchBar.js
+++ b/frontend/src/components/common/searchBar/SearchBar.js
@@ -35,10 +35,7 @@ export function AuthorInstiutionSearchBar({ onSearch, defaultAuthor, defaultInst
       return new Promise((resolve) => {
         debouncedSearch(async () => {
           try {
-            const res = await autocompleteService.autocompleteAuthors(
-              query,
-              institution == null ? '' : institution.Id
-            );
+            const res = await autocompleteService.autocompleteAuthors(query);
             resolve(res);
             return res;
           } catch (error) {

--- a/prism/openalex/openalex.go
+++ b/prism/openalex/openalex.go
@@ -69,7 +69,7 @@ type InstitutionAuthor struct {
 }
 
 type KnowledgeBase interface {
-	AutocompleteAuthor(authorNameQuery, institutionId string) ([]api.Autocompletion, error)
+	AutocompleteAuthor(query string) ([]api.Autocompletion, error)
 
 	AutocompleteInstitution(query string) ([]api.Autocompletion, error)
 

--- a/prism/openalex/remote.go
+++ b/prism/openalex/remote.go
@@ -55,11 +55,10 @@ type oaAutocompletion struct {
 	Hint        string `json:"hint"`
 }
 
-func (oa *RemoteKnowledgeBase) autocompleteHelper(component, query, filter string) ([]api.Autocompletion, error) {
+func (oa *RemoteKnowledgeBase) autocompleteHelper(component, query string) ([]api.Autocompletion, error) {
 	res, err := oa.client.R().
 		SetResult(&oaResults[oaAutocompletion]{}).
 		SetQueryParam("q", query).
-		SetQueryParam("filter", filter).
 		Get(fmt.Sprintf("/autocomplete/%s", component))
 
 	if err != nil {
@@ -86,20 +85,16 @@ func (oa *RemoteKnowledgeBase) autocompleteHelper(component, query, filter strin
 	return autocompletions, nil
 }
 
-func (oa *RemoteKnowledgeBase) AutocompleteAuthor(authorNameQuery string, institutionId string) ([]api.Autocompletion, error) {
-	var filterParam = ""
-	if institutionId != "" {
-		filterParam = fmt.Sprintf("affiliations.institution.id:%s", institutionId)
-	}
-	return oa.autocompleteHelper("authors", authorNameQuery, filterParam)
+func (oa *RemoteKnowledgeBase) AutocompleteAuthor(query string) ([]api.Autocompletion, error) {
+	return oa.autocompleteHelper("authors", query)
 }
 
 func (oa *RemoteKnowledgeBase) AutocompleteInstitution(query string) ([]api.Autocompletion, error) {
-	return oa.autocompleteHelper("institutions", query, "")
+	return oa.autocompleteHelper("institutions", query)
 }
 
 func (oa *RemoteKnowledgeBase) AutocompletePaper(query string) ([]api.Autocompletion, error) {
-	return oa.autocompleteHelper("works", query, "")
+	return oa.autocompleteHelper("works", query)
 }
 
 // Response Format: https://docs.openalex.org/api-entities/authors/get-lists-of-authors

--- a/prism/openalex/remote_test.go
+++ b/prism/openalex/remote_test.go
@@ -11,7 +11,7 @@ import (
 func TestAutocompleteAuthor(t *testing.T) {
 	oa := openalex.NewRemoteKnowledgeBase()
 
-	results, err := oa.AutocompleteAuthor("anshumali shriva", "")
+	results, err := oa.AutocompleteAuthor("anshumali shriva")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,32 +330,5 @@ func TestGetInstitutionAuthors(t *testing.T) {
 		if author.AuthorId == "" || author.AuthorName == "" {
 			t.Fatal("author info cannot be empty")
 		}
-	}
-}
-
-func TestAutoCompleteInstituteAuthor(t *testing.T) {
-	oa := openalex.NewRemoteKnowledgeBase()
-
-	results, err := oa.AutocompleteAuthor("M katherine B", "https://openalex.org/I91045830")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(results) == 0 {
-		t.Fatal("should have some results")
-	}
-
-	found := false
-	for _, res := range results {
-		if strings.EqualFold(res.Name, "M. Katherine Banks") && strings.EqualFold(res.Hint, "Texas A&M University, USA") {
-			found = true
-		}
-		if strings.EqualFold(res.Name, "M Katherine Bleckley") {
-			t.Fatal("should not have this author")
-		}
-	}
-
-	if !found {
-		t.Fatal("didn't find correct result")
 	}
 }

--- a/prism/services/autocomplete.go
+++ b/prism/services/autocomplete.go
@@ -24,9 +24,8 @@ func (s *AutocompleteService) Routes() chi.Router {
 
 func (s *AutocompleteService) AutocompleteAuthor(r *http.Request) (any, error) {
 	query := r.URL.Query().Get("query")
-	institutionId := r.URL.Query().Get("institution_id")
 
-	authors, err := s.openalex.AutocompleteAuthor(query, institutionId)
+	authors, err := s.openalex.AutocompleteAuthor(query)
 	if err != nil {
 		return nil, CodedError(err, http.StatusInternalServerError)
 	}


### PR DESCRIPTION
[PR #112](https://github.com/ThirdAILabs/PRISM/pull/112) implements the feature wherein if a university is selected, then for the author autocompletion, only the authors that are associated with the selected university are shown. 

From the users' perspective, this is a bad experience. If the user is on the author dashboard and click on back or if they simply change their mind and try to search for another author at another university, that author is not going to show up. The user doesn’t know that they have to select the university first in that case. They may think that the our dataset doesn’t have that author or that the application is flaky, where it works at times but not others.

[Jira Ticket](https://3rdai.atlassian.net/browse/PRSM-173)